### PR TITLE
Implment polyfill of scheduler.yield()

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,54 @@ The polyfill includes implementations of `Scheduler`, exposed through
 `self.scheduler`, as well as `TaskController` and `TaskPriorityChangeEvent`
 classes.
 
+## `scheduler.postTask()`
+
 The implementation uses a combination of `setTimeout`, `MessageChannel`, and
 `requestIdleCallback` to implement task scheduling, falling back to `setTimeout`
 when other APIs are not available.
+
+The polyfill, like the native implementation, runs `scheduler` tasks in
+descending priority order (`'user-blocking'` > `'user-visible'` >
+`'background'`). But there are some differences in the relative order of
+non-`scheduler` tasks:
+
+ - `"background"` tasks are scheduled using `requestIdleCallback` on browsers
+   that support it, which provides similar scheduling as `scheduler`. For
+   browsers that don't support it, these tasks do not have low/idle event loop
+   priority.
+
+ - `"user-blocking"` tasks have the same event loop scheduling prioritization as
+   `"user-visible"` (similar to `setTimeout()`), meaning these tasks do not have
+   a higher event loop priority.
+
+## `scheduler.yield()`
+
+The polyfill supports [`scheduler.yield()`](https://chromestatus.com/feature/6266249336586240),
+which is currently in [Origin Trial in
+Chrome](https://developer.chrome.com/origintrials/#/view_trial/836543630784069633).
+
+[Signal and priority
+inheritance](https://github.com/WICG/scheduling-apis/blob/main/explainers/yield-and-continuation.md#controlling-continuation-priority-and-abort-behavior)
+is not currently supported in the polyfill, and using the `"inherit"` option
+will result in the default behavior, i.e. the continuation will not be aborted
+and will run at default priority.
+
+The scheduling behavior of the polyfill depends on whether the browser supports
+`scheduler.postTask()` (i.e. older Chrome versions). If it does, then `yield()`
+is polyfilled with `postTask()`, with the following behavior:
+
+ - `"user-visible"` continuations run as `"user-blocking"` `scheduler` tasks.
+   This means they typically have a higher event loop priority than other tasks
+   (consistent with `yield()`), but they can be interleaved with other
+   `"user-blocking"` tasks. The same goes for `"user-blocking"` continuations.
+ - `"background"` continuations are scheduled as `"background"` tasks, which
+   means they have lowered event loop priority but don't go ahead of other
+   `"background"` tasks, so they can be interleaved.
+
+On browsers that don't support `scheduler.postTask()`, the same event loop
+prioritization as the `postTask()` polyfill applies (see above), but
+continuations have higher priority than tasks of the same priority, e.g.
+`"background"` continuations run before `"background"` tasks.
 
 ## Requirements
 

--- a/src/yield.js
+++ b/src/yield.js
@@ -1,0 +1,131 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Returns a promise that is resolved in a new task. The resulting promise is
+ * rejected if the associated signal is aborted. This uses scheduler.postTask()
+ * to schedule continuations.
+ *
+ * @param {{signal: AbortSignal, priorty: string}} options
+ * @return {!Promise<*>}
+ */
+function schedulerYield(options) {
+  // Map scheduler priority to continuation priority. Use 'user-blocking' to get
+  // similar scheduling behavior in the default case; leave 'background' alone
+  // so the continuations have lower priority than non-scheduler tasks.
+  const continuationPriority = (priority) => {
+    return !priority || priority == 'user-visible' ?
+        'user-blocking' : priority;
+  };
+
+  options = Object.assign({}, options);
+  // Inheritance is not supported. Use default options instead.
+  if (options.signal && options.signal == 'inherit') {
+    delete options.signal;
+  }
+  if (options.priority && options.priority == 'inherit') {
+    delete options.priority;
+  }
+
+  // The code below assumes the signal is not aborted, otherwise linking
+  // wouldn't work properly.
+  if (options.signal && options.signal.aborted) {
+    return Promise.reject(options.signal.reason);
+  }
+
+  // Priority of the continuation, used to create the signal used for
+  // scheduling.
+  let priority = options.priority;
+  if (!priority && options.signal && options.signal.priority) {
+    priority = options.signal.priority;
+  }
+  priority = continuationPriority(priority);
+
+  // To support dynamic continuation priorities and a boosted default priority,
+  // we can't pass the original options directly, e.g. changing from
+  // 'background' to 'user-visible' wouldn't have the right effective priority
+  // ('user-blocking'). To get around this, we listen and propagate 'abort' and
+  // 'prioritychange' events, adjusting the priority for the latter if
+  // necessary. This stores the state required for propagating 'abort' these
+  // events.
+  const continuation = {
+    inputSignal: options.signal,
+
+    // `controller`'s signal is used to schedule the continuation, and it
+    // propagates events from `inputSignal` to control the continuation.
+    controller: new self.TaskController({priority}),
+
+    // 'abort' event handler added to `inputSignal`, if set, to propagate abort.
+    abortCallback: null,
+
+    // 'prioritychange' event handler added to `inputSignal` to propagate
+    // priority changes. Only set if `inputSignal` is a TaskSignal and a
+    // fixed priority override wasn't provided.
+    priorityCallback: null,
+
+    onTaskAborted: function() {
+      this.controller.abort(this.inputSignal.reason);
+      this.abortCallback = null;
+    },
+
+    onPriorityChange: function() {
+      this.controller.setPriority(
+          continuationPriority(this.inputSignal.priority));
+    },
+
+    onTaskCompleted: function() {
+      if (this.abortCallback) {
+        this.inputSignal.removeEventListener('abort', this.abortCallback);
+        this.abortCallback = null;
+      }
+      if (this.priorityCallback) {
+        this.inputSignal.removeEventListener(
+            'prioritychange', this.priorityCallback);
+        this.priorityCallback = null;
+      }
+    },
+  };
+
+  // Set up 'abort' event propagation.
+  if (options.signal) {
+    continuation.abortCallback = () => {
+      continuation.onTaskAborted();
+    };
+    options.signal.addEventListener('abort', continuation.abortCallback);
+  }
+
+  // Set up 'prioritychange' event propagation. This is only relevant if the
+  // signal is a TaskSignal and a fixed priority wasn't provided.
+  if (options.signal && options.signal.priority && !options.priority) {
+    continuation.priorityCallback = () => {
+      continuation.onPriorityChange();
+    };
+    options.signal.addEventListener(
+        'prioritychange', continuation.priorityCallback);
+  }
+
+  const p = self.scheduler.postTask(
+      () => {}, {signal: continuation.controller.signal});
+  p.then(() => {
+    continuation.onTaskCompleted();
+  }).catch((e) => {
+    continuation.onTaskCompleted();
+    throw e;
+  });
+  return p;
+}
+
+export {schedulerYield};

--- a/test/test.scheduler.js
+++ b/test/test.scheduler.js
@@ -17,6 +17,7 @@
 import {Scheduler} from '../src/scheduler.js';
 import {SCHEDULER_PRIORITIES} from '../src/scheduler-priorities.js';
 import {TaskController} from '../src/task-controller.js';
+import {yieldCommonTests} from './test.yield.common.js';
 
 describe('Scheduler', function() {
   describe('#postTask()', function() {
@@ -396,5 +397,9 @@ describe('Scheduler', function() {
     } catch (e) {
       expect(e).to.equal(200);
     }
+  });
+
+  describe('#yield()', function() {
+    yieldCommonTests(new Scheduler(), TaskController, false);
   });
 });

--- a/test/test.scheduleryield.js
+++ b/test/test.scheduleryield.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,10 @@
  * limitations under the License.
  */
 
-import {Scheduler} from './scheduler.js';
-import {TaskController, TaskPriorityChangeEvent} from './task-controller.js';
-import {schedulerYield} from './yield.js';
+import {schedulerYield} from '../src/yield.js';
+import {yieldCommonTests} from './test.yield.common.js';
 
-if (typeof self.scheduler === 'undefined') {
-  self.scheduler = new Scheduler();
-  self.TaskController = TaskController;
-  self.TaskPriorityChangeEvent = TaskPriorityChangeEvent;
-} else if (!self.scheduler.yield) {
+describe('shedulerYield', function() {
   self.scheduler.yield = schedulerYield;
-}
+  yieldCommonTests(self.scheduler, self.TaskController, true);
+});

--- a/test/test.yield.common.js
+++ b/test/test.yield.common.js
@@ -1,0 +1,171 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {SCHEDULER_PRIORITIES} from '../src/scheduler-priorities.js';
+
+/**
+ * Tests that should work with either yield() polyfill.
+ *
+ * @param {!Object} scheduler
+ * @param {!Object} ControllerInterface
+ * @param {boolean} hasPostTask
+ *
+ */
+function yieldCommonTests(scheduler, ControllerInterface, hasPostTask) {
+  SCHEDULER_PRIORITIES.forEach((priority) => {
+    it('should run ' + priority + ' continuations.', function() {
+      return scheduler.yield({priority});
+    });
+  });
+
+  SCHEDULER_PRIORITIES.forEach((priority) => {
+    it('should run ' + priority + ' continuations using a signal.', function() {
+      const controller = new ControllerInterface();
+      return scheduler.yield({signal: controller.signal});
+    });
+  });
+
+  SCHEDULER_PRIORITIES.forEach((priority) => {
+    it('should run ' + priority + ' continuations in an async yieldy task.',
+        async function() {
+          for (let i = 0; i < 5; i++) {
+            await scheduler.yield({priority});
+          }
+        });
+  });
+
+  it('it should run continuations in queue order.', async function() {
+    const tasks = [];
+    let result = '';
+    // Post continuations in a way that the tasks all start before the
+    // continuations run, with either version of yield().
+    for (let i = 0; i < 3; i++) {
+      const task = scheduler.postTask(async () => {
+        await scheduler.yield({priority: 'background'});
+        result += i;
+      });
+      tasks.push(task);
+    }
+    await Promise.all(tasks);
+    expect(result).to.equal('012');
+  });
+
+  // Note: this is the only priority guaranteed to have this property in both
+  // polyfills.
+  it('it should run user-visible continuations before tasks', async () => {
+    let result = '';
+    await scheduler.postTask(async () => {
+      const p = scheduler.postTask(() => {
+        result += 'task';
+      });
+      await scheduler.yield();
+      result += 'continuation ';
+      await p;
+    });
+    expect(result).to.equal('continuation task');
+  });
+
+  it('should not fail with {priority: "inherit"}.', function() {
+    return scheduler.yield({priority: 'inherit'});
+  });
+
+  it('should not fail with {signal: "inherit"}.', function() {
+    return scheduler.yield({signal: 'inherit'});
+  });
+
+  it('should abort scheduled continuations.', async function() {
+    const controller = new ControllerInterface();
+    const p = scheduler.yield({signal: controller.signal});
+    controller.abort('abort reason');
+    try {
+      await p;
+      assert.ok(false);
+    } catch (e) {
+      expect(e).to.equal('abort reason');
+    }
+
+    // Same if passing an aborted signal.
+    try {
+      await scheduler.yield({signal: controller.signal});
+      assert.ok(false);
+    } catch (e) {
+      expect(e).to.equal('abort reason');
+    }
+  });
+
+  it('should observe priority changes.', async function() {
+    const controller = new ControllerInterface();
+    const signal = controller.signal;
+    let result = '';
+    await scheduler.postTask(async () => {
+      // user-visible continuations are guaranteed to run before user-visible
+      // tasks in both versions, so this test will fail if the priority change
+      // isn't observed.
+      const task = scheduler.postTask(() => {
+        result += 'task ';
+      });
+
+      // This will run before the user-visible continuation in the
+      // schedulerYield polyfill because it gets queued first.
+      scheduler.postTask(() => {
+        controller.setPriority('background');
+      }, {priority: 'user-blocking'});
+
+      await scheduler.yield({signal});
+      result += 'continuation';
+
+      await task;
+    });
+    expect(result).to.equal('task continuation');
+  });
+
+  // Priority tests.
+  for (let i = 0; i < 2; i++) {
+    const useSignal = i == 1;
+    const description = 'should run continutions in the expected order ' +
+        useSignal ? '(with signal).' : '(without signal).';
+    it(description, async function() {
+      const tasks = [];
+      let result = '';
+
+      [
+        {priority: 'background', id: 'bg'},
+        {priority: 'user-visible', id: 'uv'},
+        {priority: 'user-blocking', id: 'ub'},
+      ].forEach(({priority, id}) => {
+        const options = useSignal ?
+          {signal: (new ControllerInterface({priority})).signal} :
+          {priority};
+        // Schedule a task with the given priority.
+        tasks.push(scheduler.postTask(() => {
+          result += id + ', ';
+        }, options));
+        // ...and a continuation.
+        tasks.push(scheduler.yield(options).then(() => {
+          result += id + '-c, ';
+        }));
+      });
+
+      await Promise.all(tasks);
+      const expected = hasPostTask ?
+          'uv-c, ub, ub-c, uv, bg, bg-c, ' :
+          'ub-c, ub, uv-c, uv, bg-c, bg, ';
+      expect(result).to.equal(expected);
+    });
+  }
+}
+
+export {yieldCommonTests};


### PR DESCRIPTION
This adds support for scheduler.yield() for both browsers with scheduler (Chrome) and without.

If postTask is available, yield() is polyfilled with postTask(). This allows us to schedule user-visible continuations at a higher event loop priority and get similar scheduler characteristics as yield(). We can't, however, guarantee that yield() continuations always run before postTask() tasks of the same priority using this approach. In particular:
 - "user-blocking" tasks and continuations, and "user-visible" continuations can all be interleaved.
 - "background" tasks and continuations can be interleaved.

If postTask() is not available (polyfilling both), then continuations are guaranteed to run before postTask() tasks of the same priority, but continuations never have a higher event loop priority.

Implmentation notes:
 - For the version integrating with the existing polyfill, since event loop scheduling for continuations and tasks is the same, we only need to make sure to run continuations before tasks. This is handled by storing continuations in separate task queues (alongside the existing ones) and choosing continuations over tasks. postTask() was refactored into a common function for both postTask() and yield(), with the queue being chosen based on the API.

 - For the postTask version, the main challenge is getting priority change to work, e.g. when changing priority to "user-visible", the underlying tasks should be scheduled as "user-blocking". For this, we listen for priority/abort events on the signal provided in the options and forward abort and priority, with the latter being adjusted as needed.

Additionally, this updates the README with notes about event loop scheduling for postTask() and yield().