### PR TITLE
Decouple MessageChannel check

### DIFF
--- a/src/host-callback.js
+++ b/src/host-callback.js
@@ -200,7 +200,6 @@ class HostCallback {
     // the appropriate priority when the callback runs. If the delay <= 0 and
     // MessageChannel is available, we use postMessage below.
     if (delay && delay > 0) {
-      if (!delay) delay = 0;
       this.callbackType_ = CallbackType.SET_TIMEOUT;
       this.handle_ = setTimeout(() => {
         this.runCallback_();

--- a/src/host-callback.js
+++ b/src/host-callback.js
@@ -214,7 +214,7 @@ class HostCallback {
     }
 
     if (priority === 'background' &&
-      typeof requestIdleCallback === 'function') {
+        typeof requestIdleCallback === 'function') {
       this.callbackType_ = CallbackType.REQUEST_IDLE_CALLBACK;
       this.handle_ = requestIdleCallback(() => {
         this.runCallback_();
@@ -235,7 +235,7 @@ class HostCallback {
     }
 
     // Some JS environments may not support MessageChannel.
-    // This makes setTimeout the only option
+    // This makes setTimeout the only option.
     this.callbackType_ = CallbackType.SET_TIMEOUT;
     this.handle_ = setTimeout(() => {
       this.runCallback_();

--- a/src/host-callback.js
+++ b/src/host-callback.js
@@ -215,28 +215,27 @@ class HostCallback {
 
     if (priority === 'background' &&
       typeof requestIdleCallback === 'function') {
+      this.callbackType_ = CallbackType.REQUEST_IDLE_CALLBACK;
       this.handle_ = requestIdleCallback(() => {
         this.runCallback_();
       });
-      this.callbackType_ = CallbackType.REQUEST_IDLE_CALLBACK;
       return;
     }
 
     // Use MessageChannel if avaliable
     if (typeof MessageChannel === 'function') {
+      this.callbackType_ = CallbackType.POST_MESSAGE;
       // TODO: Consider using setTimeout in the background so tasks are
       // throttled. One caveat here is that requestIdleCallback may not be
       // throttled.
       this.handle_ = getPostMessageCallbackManager().queueCallback(() => {
         this.runCallback_();
       });
-      this.callbackType_ = CallbackType.POST_MESSAGE;
       return;
     }
 
     // Some JS environments may not support MessageChannel.
     // This makes setTimeout the only option
-
     this.callbackType_ = CallbackType.SET_TIMEOUT;
     this.handle_ = setTimeout(() => {
       this.runCallback_();

--- a/test/test.hostcallback.js
+++ b/test/test.hostcallback.js
@@ -55,7 +55,7 @@ describe('HostCallback', function() {
     it('should return true for background tasks if requestIdleCallback exists',
         function() {
           const hasRequestIdleCallback =
-          typeof requestIdleCallback === 'function';
+            typeof requestIdleCallback === 'function';
           const hostCallback = new HostCallback(() => { }, 'background');
           expect(hostCallback.isIdleCallback()).to.equal(
               hasRequestIdleCallback);
@@ -90,7 +90,7 @@ describe('HostCallback', function() {
             expect(hostCallback.isMessageChannelCallback()).to.equal(true);
           });
 
-      it(`should use Message channel when avaliable for "${priority}"`,
+      it(`should not use Message channel when not avaliable for "${priority}"`,
           function() {
             window.MessageChannel = null;
             const hostCallback = new HostCallback(() => { }, priority);

--- a/test/test.hostcallback.js
+++ b/test/test.hostcallback.js
@@ -27,7 +27,7 @@ describe('HostCallback', function() {
     testConfigs.forEach((test) => {
       SCHEDULER_PRIORITIES.forEach((priority) => {
         let description =
-            'should schedule and run ' + priority + ' callbacks in order';
+          'should schedule and run ' + priority + ' callbacks in order';
         description += test.delay > 0 ? ' (with delay)' : ' (without delay)';
 
         it(description, function(done) {
@@ -55,20 +55,48 @@ describe('HostCallback', function() {
     it('should return true for background tasks if requestIdleCallback exists',
         function() {
           const hasRequestIdleCallback =
-             typeof requestIdleCallback === 'function';
-          const hostCallback = new HostCallback(() => {}, 'background');
+          typeof requestIdleCallback === 'function';
+          const hostCallback = new HostCallback(() => { }, 'background');
           expect(hostCallback.isIdleCallback()).to.equal(
               hasRequestIdleCallback);
         });
 
     it('should return false for user-visible and user-blocking tasks',
         function() {
-          let hostCallback = new HostCallback(() => {}, 'user-blocking');
+          let hostCallback = new HostCallback(() => { }, 'user-blocking');
           expect(hostCallback.isIdleCallback()).to.equal(false);
 
-          hostCallback = new HostCallback(() => {}, 'user-visible');
+          hostCallback = new HostCallback(() => { }, 'user-visible');
           expect(hostCallback.isIdleCallback()).to.equal(false);
         });
+  });
+
+
+  describe('#isMessageChannelCallback()', function() {
+    let originalMessageChannel = null;
+
+    beforeEach(function() {
+      originalMessageChannel = window.MessageChannel;
+    });
+
+    afterEach(function() {
+      window.MessageChannel = originalMessageChannel;
+    });
+
+    ['user-visible', 'user-blocking'].forEach((priority) => {
+      it(`should use Message channel when avaliable for "${priority}"`,
+          function() {
+            const hostCallback = new HostCallback(() => { }, priority);
+            expect(hostCallback.isMessageChannelCallback()).to.equal(true);
+          });
+
+      it(`should use Message channel when avaliable for "${priority}"`,
+          function() {
+            window.MessageChannel = null;
+            const hostCallback = new HostCallback(() => { }, priority);
+            expect(hostCallback.isMessageChannelCallback()).to.equal(false);
+          });
+    });
   });
 
 
@@ -81,7 +109,7 @@ describe('HostCallback', function() {
     testConfigs.forEach((test) => {
       SCHEDULER_PRIORITIES.forEach((priority) => {
         let description =
-            'should prevent ' + priority + ' callbacks from running';
+          'should prevent ' + priority + ' callbacks from running';
         description += test.delay > 0 ? ' (with delay)' : ' (without delay)';
 
         it(description, function(done) {

--- a/test/test.hostcallback.js
+++ b/test/test.hostcallback.js
@@ -27,7 +27,7 @@ describe('HostCallback', function() {
     testConfigs.forEach((test) => {
       SCHEDULER_PRIORITIES.forEach((priority) => {
         let description =
-          'should schedule and run ' + priority + ' callbacks in order';
+            'should schedule and run ' + priority + ' callbacks in order';
         description += test.delay > 0 ? ' (with delay)' : ' (without delay)';
 
         it(description, function(done) {
@@ -55,18 +55,18 @@ describe('HostCallback', function() {
     it('should return true for background tasks if requestIdleCallback exists',
         function() {
           const hasRequestIdleCallback =
-            typeof requestIdleCallback === 'function';
-          const hostCallback = new HostCallback(() => { }, 'background');
+             typeof requestIdleCallback === 'function';
+          const hostCallback = new HostCallback(() => {}, 'background');
           expect(hostCallback.isIdleCallback()).to.equal(
               hasRequestIdleCallback);
         });
 
     it('should return false for user-visible and user-blocking tasks',
         function() {
-          let hostCallback = new HostCallback(() => { }, 'user-blocking');
+          let hostCallback = new HostCallback(() => {}, 'user-blocking');
           expect(hostCallback.isIdleCallback()).to.equal(false);
 
-          hostCallback = new HostCallback(() => { }, 'user-visible');
+          hostCallback = new HostCallback(() => {}, 'user-visible');
           expect(hostCallback.isIdleCallback()).to.equal(false);
         });
   });
@@ -86,14 +86,14 @@ describe('HostCallback', function() {
     ['user-visible', 'user-blocking'].forEach((priority) => {
       it(`should use Message channel when avaliable for "${priority}"`,
           function() {
-            const hostCallback = new HostCallback(() => { }, priority);
+            const hostCallback = new HostCallback(() => {}, priority);
             expect(hostCallback.isMessageChannelCallback()).to.equal(true);
           });
 
       it(`should not use Message channel when not avaliable for "${priority}"`,
           function() {
             window.MessageChannel = null;
-            const hostCallback = new HostCallback(() => { }, priority);
+            const hostCallback = new HostCallback(() => {}, priority);
             expect(hostCallback.isMessageChannelCallback()).to.equal(false);
           });
     });
@@ -109,7 +109,7 @@ describe('HostCallback', function() {
     testConfigs.forEach((test) => {
       SCHEDULER_PRIORITIES.forEach((priority) => {
         let description =
-          'should prevent ' + priority + ' callbacks from running';
+            'should prevent ' + priority + ' callbacks from running';
         description += test.delay > 0 ? ' (with delay)' : ' (without delay)';
 
         it(description, function(done) {


### PR DESCRIPTION
Fixes https://github.com/GoogleChromeLabs/scheduler-polyfill/issues/5

Changes: 
* allow React Native to use background task, if `requestIdleCallback` is available
* separate check for delay and MessageChannel
* keep setTimeout as general fallback