### PR TITLE
add global scheduler.* typescript types

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Polyfill of self.scheduler API",
   "main": "./dist/scheduler-polyfill.js",
   "module": "./dist/scheduler-polyfill.js",
+  "types": "./dist/scheduler.d.ts",
   "directories": {
     "doc": "docs"
   },
@@ -11,7 +12,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "microbundle --raw -f iife src/polyfill.js",
+    "build": "microbundle --raw --no-generateTypes -f iife src/polyfill.js && cp types/scheduler.d.ts dist/",
     "lint": "eslint src test",
     "test": "karma start --single-run --browsers ChromeHeadless karma.conf.js"
   },

--- a/types/scheduler.d.ts
+++ b/types/scheduler.d.ts
@@ -53,7 +53,7 @@ export type SchedulerYieldOptions = {
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/TaskController/TaskController#options)
  */
 type TaskControllerOptions = {
-  /** The {@link TaskPriority} of the signal associated with this {@link TaskController}. One of `"user-blocking"`, `"user-visible"`, or `"background"`. */
+  /** The {@link TaskPriority} of the signal associated with this {@link TaskController}. One of `"user-blocking"`, `"user-visible"`, or `"background"`. The default is `"user-visible"`. */
   priority?: TaskPriority;
 }
 
@@ -104,7 +104,7 @@ declare global {
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/TaskPriorityChangeEvent)
    */
   class TaskPriorityChangeEvent extends Event {
-    constructor(type: string, init?: TaskPriorityChangeEventInit);
+    constructor(type: string, init: TaskPriorityChangeEventInit);
     /**
      * The priority of the corresponding {@link TaskSignal} _before_ this prioritychange event.
      *

--- a/types/scheduler.d.ts
+++ b/types/scheduler.d.ts
@@ -1,0 +1,142 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Task priorities that determine the order in which tasks run.
+ *
+ * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Prioritized_Task_Scheduling_API#task_priorities)
+ */
+export type TaskPriority = 'user-blocking' | 'user-visible' | 'background';
+
+/**
+ * {@link Scheduler.postTask} options.
+ *
+ * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Scheduler/postTask#options)
+ */
+export type SchedulerPostTaskOptions = {
+  /** The immutable {@link TaskPriority} of the task. One of `"user-blocking"`, `"user-visible"`, or `"background"`. If set, this priority is used for the lifetime of the task and priority set on the `signal` is ignored. */
+  priority?: TaskPriority;
+  /** An {@link AbortSignal} or {@link TaskSignal} that can be used to abort or re-prioritize the task (from its associated controller). */
+  signal?: AbortSignal | TaskSignal;
+  /** The minimum amount of time after which the task will be added to the scheduler queue, in whole milliseconds. The actual delay may be higher than specified, but will not be less. The default delay is 0. */
+  delay?: number;
+};
+
+/**
+ * {@link Scheduler.yield} options.
+ *
+ * [Explainer reference](https://github.com/WICG/scheduling-apis/blob/main/explainers/yield-and-continuation.md#controlling-continuation-priority-and-abort-behavior)
+ */
+export type SchedulerYieldOptions = {
+  /** The priority for the continuation, either a {@link TaskPriority} (`"user-blocking"`, `"user-visible"`, or `"background"`) or `"inherit"` to infer the priority from the current context. */
+  priority?: TaskPriority | 'inherit';
+  /** An {@link AbortSignal} or {@link TaskSignal} that can be used to abort or re-prioritize the task (from its associated controller), or `"inherit"` to inherit the current task's signal. */
+  signal?: AbortSignal | TaskSignal | 'inherit';
+};
+
+/**
+ * {@link TaskController} options.
+ *
+ * [MDN Reference](https://developer.mozilla.org/docs/Web/API/TaskController/TaskController#options)
+ */
+type TaskControllerOptions = {
+  /** The {@link TaskPriority} of the signal associated with this {@link TaskController}. One of `"user-blocking"`, `"user-visible"`, or `"background"`. */
+  priority?: TaskPriority;
+}
+
+/** [MDN Reference](https://developer.mozilla.org/docs/Web/API/TaskPriorityChangeEvent/TaskPriorityChangeEvent#options) */
+interface TaskPriorityChangeEventInit extends EventInit {
+  /** A string indicating the previous priority of the task. One of `"user-blocking"`, `"user-visible"`, or `"background"`. */
+  previousPriority: TaskPriority;
+}
+
+declare global {
+  /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Scheduler) */
+  interface Scheduler {
+    /**
+     * Adds a task to the scheduler as a callback, optionally specifying a priority, delay, and/or a signal for aborting the task.
+     * @param callback An callback function that implements the task. The return value of the callback is used to resolve the promise returned by this function.
+     * @param options {@link SchedulerPostTaskOptions} options.
+     *
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Scheduler/postTask)
+     */
+    postTask<T extends unknown>(callback: () => T, options?: SchedulerPostTaskOptions): Promise<T>;
+    /**
+     * Returns a promise that yields to the event loop when awaited. Optionally specify a priority and/or a signal for aborting the task.
+     * @param options {@link SchedulerYieldOptions} options.
+     */
+    yield(options?: SchedulerYieldOptions): Promise<void>;
+  }
+
+  /**
+   * A controller object that can be used to both abort and change the priority of one or more prioritized tasks.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/TaskController)
+   */
+  class TaskController extends AbortController {
+    constructor(options?: TaskControllerOptions);
+    /** Returns a {@link TaskSignal} instance. The signal is passed to tasks so that they can be aborted or re-prioritized by the controller. */
+    readonly signal: TaskSignal;
+    /**
+     * Sets the priority of the controller's signal, and hence the priority of any tasks with which it is associated.
+     *
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/TaskController/setPriority)
+     */
+    setPriority(priority: TaskPriority): void;
+  }
+
+  /**
+   * The `prioritychange` event, sent to a {@link TaskSignal} if its priority is changed.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/TaskPriorityChangeEvent)
+   */
+  class TaskPriorityChangeEvent extends Event {
+    constructor(type: string, init?: TaskPriorityChangeEventInit);
+    /**
+     * The priority of the corresponding {@link TaskSignal} _before_ this prioritychange event.
+     *
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/TaskPriorityChangeEvent/previousPriority)
+     */
+    readonly previousPriority: TaskPriority;
+  }
+
+  /**
+   * A signal object that allows you to communicate with a prioritized task, aborting it or changing the priority (if required) via a {@link TaskController} object.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/TaskSignal)
+   */
+  class TaskSignal extends AbortSignal {
+    /**
+     * The priority of the signal.
+     *
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/TaskSignal/priority)
+     */
+    readonly priority: TaskPriority;
+    /**
+     * Fired when the priority is changed.
+     *
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/TaskSignal/prioritychange_event)
+     */
+    onprioritychange: (event: TaskPriorityChangeEvent) => void;
+  }
+
+  /**
+   * The global {@link Scheduler} entry point for using the Prioritized Task Scheduling API.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/scheduler)
+   */
+  const scheduler: Scheduler;
+}

--- a/types/scheduler.d.ts
+++ b/types/scheduler.d.ts
@@ -29,7 +29,7 @@ export type TaskPriority = 'user-blocking' | 'user-visible' | 'background';
 export type SchedulerPostTaskOptions = {
   /** The immutable {@link TaskPriority} of the task. One of `"user-blocking"`, `"user-visible"`, or `"background"`. If set, this priority is used for the lifetime of the task and priority set on the `signal` is ignored. */
   priority?: TaskPriority;
-  /** An {@link AbortSignal} or {@link TaskSignal} that can be used to abort or re-prioritize the task (from its associated controller). */
+  /** An {@link AbortSignal} or {@link TaskSignal} that can be used to abort or re-prioritize the task (from its associated controller). The signal's priority is ignored if `priority` is set. */
   signal?: AbortSignal | TaskSignal;
   /** The minimum amount of time after which the task will be added to the scheduler queue, in whole milliseconds. The actual delay may be higher than specified, but will not be less. The default delay is 0. */
   delay?: number;
@@ -41,9 +41,9 @@ export type SchedulerPostTaskOptions = {
  * [Explainer reference](https://github.com/WICG/scheduling-apis/blob/main/explainers/yield-and-continuation.md#controlling-continuation-priority-and-abort-behavior)
  */
 export type SchedulerYieldOptions = {
-  /** The priority for the continuation, either a {@link TaskPriority} (`"user-blocking"`, `"user-visible"`, or `"background"`) or `"inherit"` to infer the priority from the current context. */
+  /** The priority for the continuation, either a {@link TaskPriority} (`"user-blocking"`, `"user-visible"`, or `"background"`) or `"inherit"` to infer the priority from the current context. If set, this priority is used for the lifetime of the task and priority set on the `signal` is ignored. */
   priority?: TaskPriority | 'inherit';
-  /** An {@link AbortSignal} or {@link TaskSignal} that can be used to abort or re-prioritize the task (from its associated controller), or `"inherit"` to inherit the current task's signal. */
+  /** An {@link AbortSignal} or {@link TaskSignal} that can be used to abort or re-prioritize the task (from its associated controller), or `"inherit"` to inherit the current task's signal. The signal's priority is ignored if `priority` is set. */
   signal?: AbortSignal | TaskSignal | 'inherit';
 };
 
@@ -68,7 +68,7 @@ declare global {
   interface Scheduler {
     /**
      * Adds a task to the scheduler as a callback, optionally specifying a priority, delay, and/or a signal for aborting the task.
-     * @param callback An callback function that implements the task. The return value of the callback is used to resolve the promise returned by this function.
+     * @param callback A callback function that implements the task. The return value of the callback is used to resolve the promise returned by this function.
      * @param options {@link SchedulerPostTaskOptions} options.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Scheduler/postTask)


### PR DESCRIPTION
Adds typescript types for `scheduler`, `TaskController`, `TaskSignal`, etc. When the polyfill is imported, the types will be added to `globalThis` for supported environments, e.g. in vscode, you'll get code completions with doc strings and links to documentation.

![A demonstration of using scheduler code and getting vscode to offer code completion and doc strings](https://github.com/GoogleChromeLabs/scheduler-polyfill/assets/316891/e684cfdc-c03a-41cc-9845-9665bf9901ab)

If a project has a tsconfig file, the types can be used to type check `scheduler` typescript code or javascript with jsdoc. `scheduler.postTask`'s return type is nicely parameterized based on its callback's return type.

---

I styled the doc strings like typescript's [typical treatment of DOM APIs](https://github.com/microsoft/TypeScript/blob/b5b6048bb3c4a1c8272c85062bc0b585fcb99754/src/lib/dom.generated.d.ts#L2293-L2298), with a description and a link to the MDN docs (where there is one, falling back to the explainer for `scheduler.yield`). Typical example:

<img width="511" alt="The information shown on hovering over TaskController in vscode, with a doc string describing the class and a link to mdn documentation" src="https://github.com/GoogleChromeLabs/scheduler-polyfill/assets/316891/3fa3c466-c809-4e10-a965-5cd7d2e7f71c">

However the strings are probably of varying quality so happy to change anything and everything :)