### PR TITLE
Remove scheduler.yield() parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # Scheduler Polyfill
 
 This is a polyfill for the [Prioritized Task Scheduling
-API](https://wicg.github.io/scheduling-apis/). Documentation on the API shape
-along with examples can be found in the
-[explainer](https://github.com/WICG/scheduling-apis/blob/main/explainers/prioritized-post-task.md#api-shape).
+API](https://wicg.github.io/scheduling-apis/). Documentation can be found on
+[MDN](https://developer.mozilla.org/en-US/docs/Web/API/Scheduler).
 
 The polyfill includes implementations of `Scheduler`, exposed through
 `self.scheduler`, as well as `TaskController` and `TaskPriorityChangeEvent`
@@ -31,42 +30,28 @@ non-`scheduler` tasks:
 
 ## `scheduler.yield()`
 
-> `scheduler.yield()` is available in version 1.3 of the polyfill, published
-under the `next` tag on npm. See the [Usage section](#usage) for installation
-instructions.
+The polyfill does not support [priority or signal
+inheritance](https://developer.mozilla.org/en-US/docs/Web/API/Scheduler/yield#inheriting_task_priorities),
+so all continuations are scheduled with `"user-visible"` continuation priority.
+The scheduling behavior of this depends on whether the browser supports
+`scheduler.postTask()` (i.e. older Chrome versions):
+  * For browsers that support `scheduler.postTask()`, `scheduler.yield()` is
+    polyfilled with `"user-blocking"` `scheduler.postTask()` tasks. This means
+    they typically have a higher event loop priority than other tasks
+    (consistent with `yield()`), but they can be interleaved with other
+    `"user-blocking"` tasks.
 
-The polyfill supports [`scheduler.yield()`](https://chromestatus.com/feature/6266249336586240),
-which is currently in [Origin Trial in
-Chrome](https://developer.chrome.com/origintrials/#/view_trial/836543630784069633).
-
-[Signal and priority
-inheritance](https://github.com/WICG/scheduling-apis/blob/main/explainers/yield-and-continuation.md#controlling-continuation-priority-and-abort-behavior)
-is not currently supported in the polyfill, and using the `"inherit"` option
-will result in the default behavior, i.e. the continuation will not be aborted
-and will run at default priority.
-
-The scheduling behavior of the polyfill depends on whether the browser supports
-`scheduler.postTask()` (i.e. older Chrome versions). If it does, then `yield()`
-is polyfilled with `postTask()`, with the following behavior:
-
- - `"user-visible"` continuations run as `"user-blocking"` `scheduler` tasks.
-   This means they typically have a higher event loop priority than other tasks
-   (consistent with `yield()`), but they can be interleaved with other
-   `"user-blocking"` tasks. The same goes for `"user-blocking"` continuations.
- - `"background"` continuations are scheduled as `"background"` tasks, which
-   means they have lowered event loop priority but don't go ahead of other
-   `"background"` tasks, so they can be interleaved.
-
-On browsers that don't support `scheduler.postTask()`, the same event loop
-prioritization as the `postTask()` polyfill applies (see above), but
-continuations have higher priority than tasks of the same priority, e.g.
-`"background"` continuations run before `"background"` tasks.
+ * On browsers that don't support `scheduler.postTask()`, the same event loop
+   prioritization as the `postTask()` polyfill applies (see above), but
+   continuations run between `"user-blocking"` and `"user-visible"` tasks.
 
 ## Requirements
 
 A browser that supports ES6 is required for this polyfill.
 
 ## Usage
+
+**TODO(shaseley)**: Update this when we figure out the versioning.
 
 ### Include via unpkg
 

--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -62,22 +62,14 @@ class Scheduler {
   }
 
   /**
-   * Returns a promise that is resolved in a new task. The resulting promise is
-   * rejected if the associated signal is aborted.
+   * Returns a promise that is resolved in a new task.
    *
-   * @param {{signal: AbortSignal, priorty: string}} options
    * @return {!Promise<*>}
    */
-  yield(options) {
-    options = Object.assign({}, options);
+  yield() {
     // Inheritance is not supported. Use default options instead.
-    if (options.signal && options.signal == 'inherit') {
-      delete options.signal;
-    }
-    if (options.priority && options.priority == 'inherit') {
-      options.priority = 'user-visible';
-    }
-    return this.postTaskOrContinuation_(() => {}, options, true);
+    return this.postTaskOrContinuation_(
+        () => {}, {priority: 'user-visible'}, true);
   }
 
   /**

--- a/src/yield.js
+++ b/src/yield.js
@@ -15,8 +15,15 @@
  */
 
 /**
- * Returns a promise that is resolved in a new task. This uses
- * scheduler.postTask() to schedule continuations.
+ * @fileoverview This version of scheduler.yield() is only used if
+ * self.scheduler is defined. It assumes that this is the native implementation
+ * (i.e. running in an older browser), and it uses scheduler.postTask() to
+ * schedule continuations at 'user-blocking' priority.
+ */
+
+/**
+ * Returns a promise that is resolved in a new task. This schedules
+ * continuations as 'user-blocking' scheduler.postTask() tasks.
  *
  * @return {!Promise<*>}
  */

--- a/src/yield.js
+++ b/src/yield.js
@@ -15,117 +15,16 @@
  */
 
 /**
- * Returns a promise that is resolved in a new task. The resulting promise is
- * rejected if the associated signal is aborted. This uses scheduler.postTask()
- * to schedule continuations.
+ * Returns a promise that is resolved in a new task. This uses
+ * scheduler.postTask() to schedule continuations.
  *
- * @param {{signal: AbortSignal, priorty: string}} options
  * @return {!Promise<*>}
  */
-function schedulerYield(options) {
-  // Map scheduler priority to continuation priority. Use 'user-blocking' to get
-  // similar scheduling behavior in the default case; leave 'background' alone
-  // so the continuations have lower priority than non-scheduler tasks.
-  const continuationPriority = (priority) => {
-    return !priority || priority == 'user-visible' ?
-        'user-blocking' : priority;
-  };
-
-  options = Object.assign({}, options);
-  // Inheritance is not supported. Use default options instead.
-  if (options.signal && options.signal == 'inherit') {
-    delete options.signal;
-  }
-  if (options.priority && options.priority == 'inherit') {
-    delete options.priority;
-  }
-
-  // The code below assumes the signal is not aborted, otherwise linking
-  // wouldn't work properly.
-  if (options.signal && options.signal.aborted) {
-    return Promise.reject(options.signal.reason);
-  }
-
-  // Priority of the continuation, used to create the signal used for
-  // scheduling.
-  let priority = options.priority;
-  if (!priority && options.signal && options.signal.priority) {
-    priority = options.signal.priority;
-  }
-  priority = continuationPriority(priority);
-
-  // To support dynamic continuation priorities and a boosted default priority,
-  // we can't pass the original options directly, e.g. changing from
-  // 'background' to 'user-visible' wouldn't have the right effective priority
-  // ('user-blocking'). To get around this, we listen and propagate 'abort' and
-  // 'prioritychange' events, adjusting the priority for the latter if
-  // necessary. This stores the state required for propagating 'abort' these
-  // events.
-  const continuation = {
-    inputSignal: options.signal,
-
-    // `controller`'s signal is used to schedule the continuation, and it
-    // propagates events from `inputSignal` to control the continuation.
-    controller: new self.TaskController({priority}),
-
-    // 'abort' event handler added to `inputSignal`, if set, to propagate abort.
-    abortCallback: null,
-
-    // 'prioritychange' event handler added to `inputSignal` to propagate
-    // priority changes. Only set if `inputSignal` is a TaskSignal and a
-    // fixed priority override wasn't provided.
-    priorityCallback: null,
-
-    onTaskAborted: function() {
-      this.controller.abort(this.inputSignal.reason);
-      this.abortCallback = null;
-    },
-
-    onPriorityChange: function() {
-      this.controller.setPriority(
-          continuationPriority(this.inputSignal.priority));
-    },
-
-    onTaskCompleted: function() {
-      if (this.abortCallback) {
-        this.inputSignal.removeEventListener('abort', this.abortCallback);
-        this.abortCallback = null;
-      }
-      if (this.priorityCallback) {
-        this.inputSignal.removeEventListener(
-            'prioritychange', this.priorityCallback);
-        this.priorityCallback = null;
-      }
-    },
-  };
-
-  // Set up 'abort' event propagation.
-  if (options.signal) {
-    continuation.abortCallback = () => {
-      continuation.onTaskAborted();
-    };
-    options.signal.addEventListener('abort', continuation.abortCallback);
-  }
-
-  // Set up 'prioritychange' event propagation. This is only relevant if the
-  // signal is a TaskSignal and a fixed priority wasn't provided.
-  if (options.signal && options.signal.priority && !options.priority) {
-    continuation.priorityCallback = () => {
-      continuation.onPriorityChange();
-    };
-    options.signal.addEventListener(
-        'prioritychange', continuation.priorityCallback);
-  }
-
-  const p = self.scheduler.postTask(
-      () => {}, {signal: continuation.controller.signal});
-  p.then(() => {
-    continuation.onTaskCompleted();
-  }).catch((e) => {
-    continuation.onTaskCompleted();
-    throw e;
-  });
-  return p;
+function schedulerYield() {
+  // Use 'user-blocking' priority to get similar scheduling behavior as
+  // scheduler.yield(). Note: we can't reliably inherit priority and abort since
+  // we lose context if async functions are spread across multiple tasks.
+  return self.scheduler.postTask(() => {}, {priority: 'user-blocking'});
 }
 
 export {schedulerYield};

--- a/test/test.yield.common.js
+++ b/test/test.yield.common.js
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import {SCHEDULER_PRIORITIES} from '../src/scheduler-priorities.js';
-
 /**
  * Tests that should work with either yield() polyfill.
  *
@@ -25,26 +23,14 @@ import {SCHEDULER_PRIORITIES} from '../src/scheduler-priorities.js';
  *
  */
 function yieldCommonTests(scheduler, ControllerInterface, hasPostTask) {
-  SCHEDULER_PRIORITIES.forEach((priority) => {
-    it('should run ' + priority + ' continuations.', function() {
-      return scheduler.yield({priority});
-    });
+  it('should run continuations.', function() {
+    return scheduler.yield();
   });
 
-  SCHEDULER_PRIORITIES.forEach((priority) => {
-    it('should run ' + priority + ' continuations using a signal.', function() {
-      const controller = new ControllerInterface();
-      return scheduler.yield({signal: controller.signal});
-    });
-  });
-
-  SCHEDULER_PRIORITIES.forEach((priority) => {
-    it('should run ' + priority + ' continuations in an async yieldy task.',
-        async function() {
-          for (let i = 0; i < 5; i++) {
-            await scheduler.yield({priority});
-          }
-        });
+  it('should run continuations in an async yieldy task.', async function() {
+    for (let i = 0; i < 5; i++) {
+      await scheduler.yield();
+    }
   });
 
   it('it should run continuations in queue order.', async function() {
@@ -54,7 +40,7 @@ function yieldCommonTests(scheduler, ControllerInterface, hasPostTask) {
     // continuations run, with either version of yield().
     for (let i = 0; i < 3; i++) {
       const task = scheduler.postTask(async () => {
-        await scheduler.yield({priority: 'background'});
+        await scheduler.yield();
         result += i;
       });
       tasks.push(task);
@@ -63,8 +49,6 @@ function yieldCommonTests(scheduler, ControllerInterface, hasPostTask) {
     expect(result).to.equal('012');
   });
 
-  // Note: this is the only priority guaranteed to have this property in both
-  // polyfills.
   it('it should run user-visible continuations before tasks', async () => {
     let result = '';
     await scheduler.postTask(async () => {
@@ -78,94 +62,47 @@ function yieldCommonTests(scheduler, ControllerInterface, hasPostTask) {
     expect(result).to.equal('continuation task');
   });
 
-  it('should not fail with {priority: "inherit"}.', function() {
-    return scheduler.yield({priority: 'inherit'});
-  });
-
-  it('should not fail with {signal: "inherit"}.', function() {
-    return scheduler.yield({signal: 'inherit'});
-  });
-
-  it('should abort scheduled continuations.', async function() {
+  it('should not abort scheduled continuations.', async function() {
+    // The polyfill doesn't support inheritance, so the yield promise won't be
+    // rejected.
     const controller = new ControllerInterface();
-    const p = scheduler.yield({signal: controller.signal});
-    controller.abort('abort reason');
-    try {
-      await p;
-      assert.ok(false);
-    } catch (e) {
-      expect(e).to.equal('abort reason');
-    }
-
-    // Same if passing an aborted signal.
-    try {
-      await scheduler.yield({signal: controller.signal});
-      assert.ok(false);
-    } catch (e) {
-      expect(e).to.equal('abort reason');
-    }
-  });
-
-  it('should observe priority changes.', async function() {
-    const controller = new ControllerInterface();
-    const signal = controller.signal;
-    let result = '';
-    await scheduler.postTask(async () => {
-      // user-visible continuations are guaranteed to run before user-visible
-      // tasks in both versions, so this test will fail if the priority change
-      // isn't observed.
-      const task = scheduler.postTask(() => {
-        result += 'task ';
-      });
-
-      // This will run before the user-visible continuation in the
-      // schedulerYield polyfill because it gets queued first.
-      scheduler.postTask(() => {
-        controller.setPriority('background');
-      }, {priority: 'user-blocking'});
-
-      await scheduler.yield({signal});
-      result += 'continuation';
-
-      await task;
-    });
-    expect(result).to.equal('task continuation');
+    scheduler.postTask(async () => {
+      const p = scheduler.yield();
+      controller.abort('abort reason');
+      try {
+        await p;
+      } catch (e) {
+        assert.ok(false);
+      }
+    }, {signal: controller.signal}).catch(() => {});
   });
 
   // Priority tests.
-  for (let i = 0; i < 2; i++) {
-    const useSignal = i == 1;
-    const description = 'should run continutions in the expected order ' +
-        useSignal ? '(with signal).' : '(without signal).';
-    it(description, async function() {
-      const tasks = [];
-      let result = '';
+  it('should run continutions in the expected order', async function() {
+    const tasks = [];
+    let result = '';
 
-      [
-        {priority: 'background', id: 'bg'},
-        {priority: 'user-visible', id: 'uv'},
-        {priority: 'user-blocking', id: 'ub'},
-      ].forEach(({priority, id}) => {
-        const options = useSignal ?
-          {signal: (new ControllerInterface({priority})).signal} :
-          {priority};
-        // Schedule a task with the given priority.
-        tasks.push(scheduler.postTask(() => {
-          result += id + ', ';
-        }, options));
-        // ...and a continuation.
-        tasks.push(scheduler.yield(options).then(() => {
-          result += id + '-c, ';
-        }));
-      });
-
-      await Promise.all(tasks);
-      const expected = hasPostTask ?
-          'uv-c, ub, ub-c, uv, bg, bg-c, ' :
-          'ub-c, ub, uv-c, uv, bg-c, bg, ';
-      expect(result).to.equal(expected);
+    [
+      {priority: 'background', id: 'bg'},
+      {priority: 'user-visible', id: 'uv'},
+      {priority: 'user-blocking', id: 'ub'},
+    ].forEach(({priority, id}) => {
+      // Schedule a task with the given priority.
+      tasks.push(scheduler.postTask(() => {
+        result += id + ', ';
+      }, {priority}));
+      // ...and a continuation with default priority.
+      tasks.push(scheduler.yield().then(() => {
+        result += 'uv-c, ';
+      }));
     });
-  }
+
+    await Promise.all(tasks);
+    const expected = hasPostTask ?
+        'uv-c, uv-c, ub, uv-c, uv, bg, ' :
+        'ub, uv-c, uv-c, uv-c, uv, bg, ';
+    expect(result).to.equal(expected);
+  });
 }
 
 export {yieldCommonTests};


### PR DESCRIPTION
scheduler.yield() shipped in Chrome M129, but without support for parameters. This might be revisited in the future if needed, but for now this removes the parameters to keep the API shape in line with what shipped.

Fixes #15 