### PR TITLE
Small improvements to build size

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
   "browserslist": [
     "supports es6-module"
   ],
+  "mangle": {
+    "regex": "_$"
+  },
   "author": "The Chromium Authors",
   "license": "Apache-2.0",
   "keywords": [

--- a/src/host-callback.js
+++ b/src/host-callback.js
@@ -57,7 +57,7 @@ class PostMessageCallbackMananger {
    * @param {function(): undefined} callback
    * @return {number} A handle that can used for cancellation.
    */
-  queueCallback(callback) {
+  queueCallback_(callback) {
     // We support multiple pending postMessage callbacks by associating a handle
     // with each message, which is used to look up the callback when the message
     // is received.
@@ -70,7 +70,7 @@ class PostMessageCallbackMananger {
   /**
    * @param {number} handle The handle returned when the callback was queued.
    */
-  cancelCallback(handle) {
+  cancelCallback_(handle) {
     delete this.messages_[handle];
   }
 
@@ -161,7 +161,7 @@ class HostCallback {
    * Returns true iff this task was scheduled with MessageChannel.
    * @return {boolean}
    */
-  isMessageChannelCallback() {
+  isMessageChannelCallback_() {
     return this.callbackType_ === CallbackType.POST_MESSAGE;
   }
 
@@ -180,7 +180,7 @@ class HostCallback {
         clearTimeout(this.handle_);
         break;
       case CallbackType.POST_MESSAGE:
-        getPostMessageCallbackManager().cancelCallback(this.handle_);
+        getPostMessageCallbackManager().cancelCallback_(this.handle_);
         break;
       default:
         throw new TypeError('Unknown CallbackType');
@@ -228,7 +228,7 @@ class HostCallback {
       // TODO: Consider using setTimeout in the background so tasks are
       // throttled. One caveat here is that requestIdleCallback may not be
       // throttled.
-      this.handle_ = getPostMessageCallbackManager().queueCallback(() => {
+      this.handle_ = getPostMessageCallbackManager().queueCallback_(() => {
         this.runCallback_();
       });
       return;

--- a/src/intrusive-task-queue.js
+++ b/src/intrusive-task-queue.js
@@ -124,24 +124,6 @@ class IntrusiveTaskQueue {
   }
 
   /**
-   * Returns an array containing the elements of this task queue in order. This
-   * is meant to be used for debugging and might be removed.
-   *
-   * TODO(shaseley): consider removing this.
-   *
-   * @return {!Array<!Object>}
-   */
-  toArray() {
-    let node = this.head_;
-    const a = [];
-    while (node !== null) {
-      a.push(node);
-      node = node.tq_next_;
-    }
-    return a;
-  }
-
-  /**
    * Insert `task` into this queue directly after `parentTask`.
    * @private
    * @param {!Object} task The task to insert.
@@ -185,4 +167,21 @@ class IntrusiveTaskQueue {
   }
 }
 
-export {IntrusiveTaskQueue};
+/**
+ * Returns an array containing the elements of this task queue in order. This
+ * is meant to be used for debugging and might be removed.
+ *
+ * @param {IntrusiveTaskQueue} queue
+ * @return {!Array<!Object>}
+ */
+function toArray(queue) {
+  let node = queue.head_;
+  const a = [];
+  while (node !== null) {
+    a.push(node);
+    node = node.tq_next_;
+  }
+  return a;
+}
+
+export {IntrusiveTaskQueue, toArray};

--- a/test/test.hostcallback.js
+++ b/test/test.hostcallback.js
@@ -72,7 +72,7 @@ describe('HostCallback', function() {
   });
 
 
-  describe('#isMessageChannelCallback()', function() {
+  describe('#isMessageChannelCallback_()', function() {
     let originalMessageChannel = null;
 
     beforeEach(function() {
@@ -87,14 +87,14 @@ describe('HostCallback', function() {
       it(`should use Message channel when avaliable for "${priority}"`,
           function() {
             const hostCallback = new HostCallback(() => {}, priority);
-            expect(hostCallback.isMessageChannelCallback()).to.equal(true);
+            expect(hostCallback.isMessageChannelCallback_()).to.equal(true);
           });
 
       it(`should not use Message channel when not avaliable for "${priority}"`,
           function() {
             window.MessageChannel = null;
             const hostCallback = new HostCallback(() => {}, priority);
-            expect(hostCallback.isMessageChannelCallback()).to.equal(false);
+            expect(hostCallback.isMessageChannelCallback_()).to.equal(false);
           });
     });
   });


### PR DESCRIPTION
The main improvement (in d9766b8) is to turn on [terser property-name mangling](https://github.com/developit/microbundle/blob/4b11285f27e7fa5a5f9ff4733489bb75e8a0763d/README.md#mangling-properties) for any property with a leading underscore, since they're all intended to be class-private anyways, so doing this doesn't run into [any of the issues](https://github.com/terser/terser?tab=readme-ov-file#cli-mangling-property-names---mangle-props) with using terser for general property renaming.

This brings the polyfill from 7998 bytes (2170 bytes with brotli) to 6481 bytes (2004 bytes with brotli).

The second commit (9bd39db) is some optional code tweaks to better minify a few small parts. Together they bring down the polyfill size to 6341 bytes (1970 bytes with brotli). All in all, about 20% fewer raw bytes, 9% fewer brotli bytes, nice, though not the biggest deal since the brotlied size is already so small. We can brag about sub-2KB now, I guess :)

There are some additional changes that could be made, like making the [scheduler-internal task properties](https://github.com/GoogleChromeLabs/scheduler-polyfill/blob/41a62e34492492d7d1ddd3a86a4fd399f78c5dd7/src/scheduler.js#L138-L180) underscored, but the mixture of new properties and properties taken from the `options` felt fiddly and it starting feeling like something a compiler should be doing, not a person, so I let it be.