### PR TITLE
v1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,30 +51,10 @@ A browser that supports ES6 is required for this polyfill.
 
 ## Usage
 
-**TODO(shaseley)**: Update this when we figure out the versioning.
-
-### Include via unpkg
-
-**Use the next version of the polyfill, which includes `scheduler.yield()`:**
-```html
-<script src="https://unpkg.com/scheduler-polyfill@next"></script>
-```
-
-**or use the current stable release of the polyfill:**
-```html
-<script src="https://unpkg.com/scheduler-polyfill"></script>
-```
-
 ### Include via npm and a bundler
 
 ```console
 npm install scheduler-polyfill@next
-```
-
-**Or use the stable release (without `scheduler.yield()`):**
-
-```sh
-npm install scheduler-polyfill
 ```
 
 Import to populate the task scheduling global variables, if not already
@@ -82,6 +62,12 @@ available in the executing browser:
 
 ```js
 import 'scheduler-polyfill';
+```
+
+### Include via unpkg
+
+```html
+<script src="https://unpkg.com/scheduler-polyfill"></script>
 ```
 
 ### Building from source

--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ A browser that supports ES6 is required for this polyfill.
 ### Include via npm and a bundler
 
 ```console
-npm install scheduler-polyfill@next
+npm install scheduler-polyfill
 ```
 
-Import to populate the task scheduling global variables, if not already
+Import to populate the task-scheduling global variables, if not already
 available in the executing browser:
 
 ```js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scheduler-polyfill",
-  "version": "1.3.0-beta.0",
+  "version": "1.3.0",
   "description": "Polyfill of self.scheduler API",
   "main": "./dist/scheduler-polyfill.js",
   "module": "./dist/scheduler-polyfill.js",

--- a/types/scheduler.d.ts
+++ b/types/scheduler.d.ts
@@ -36,18 +36,6 @@ export type SchedulerPostTaskOptions = {
 };
 
 /**
- * {@link Scheduler.yield} options.
- *
- * [Explainer reference](https://github.com/WICG/scheduling-apis/blob/main/explainers/yield-and-continuation.md#controlling-continuation-priority-and-abort-behavior)
- */
-export type SchedulerYieldOptions = {
-  /** The priority for the continuation, either a {@link TaskPriority} (`"user-blocking"`, `"user-visible"`, or `"background"`) or `"inherit"` to infer the priority from the current context. If set, this priority is used for the lifetime of the task and priority set on the `signal` is ignored. */
-  priority?: TaskPriority | 'inherit';
-  /** An {@link AbortSignal} or {@link TaskSignal} that can be used to abort or re-prioritize the task (from its associated controller), or `"inherit"` to inherit the current task's signal. The signal's priority is ignored if `priority` is set. */
-  signal?: AbortSignal | TaskSignal | 'inherit';
-};
-
-/**
  * {@link TaskController} options.
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/TaskController/TaskController#options)
@@ -75,10 +63,11 @@ declare global {
      */
     postTask<T extends unknown>(callback: () => T, options?: SchedulerPostTaskOptions): Promise<T>;
     /**
-     * Returns a promise that yields to the event loop when awaited. Optionally specify a priority and/or a signal for aborting the task.
-     * @param options {@link SchedulerYieldOptions} options.
+     * Returns a promise that yields to the event loop when awaited, allowing continuation in a new task.
+     *
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Scheduler/yield)
      */
-    yield(options?: SchedulerYieldOptions): Promise<void>;
+    yield(): Promise<void>;
   }
 
   /**


### PR DESCRIPTION
Bump version to 1.3.0 for publishing the polyfill to npm with the shipping version of `scheduler.yield()` (updated in #16).

Also:
- updates the readme to remove mention of `scheduler-polyfill@next` since we no longer need the pre-release version on npm
- removes `SchedulerYieldOptions` from the `scheduler.d.ts` types to match the shipping `scheduler.yield()`