### PR TITLE
Implement `TaskSignal` class

### DIFF
--- a/src/polyfill.js
+++ b/src/polyfill.js
@@ -13,14 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import {Scheduler} from './scheduler.js';
-import {TaskController, TaskPriorityChangeEvent} from './task-controller.js';
+import {TaskController, TaskSignal, TaskPriorityChangeEvent}
+  from './task-controller.js';
 import {schedulerYield} from './yield.js';
 
 if (typeof self.scheduler === 'undefined') {
   self.scheduler = new Scheduler();
   self.TaskController = TaskController;
+  self.TaskSignal = TaskSignal;
   self.TaskPriorityChangeEvent = TaskPriorityChangeEvent;
 } else if (!self.scheduler.yield) {
   self.scheduler.yield = schedulerYield;

--- a/src/task-controller.js
+++ b/src/task-controller.js
@@ -23,17 +23,6 @@ import {SCHEDULER_PRIORITIES} from './scheduler-priorities.js';
  */
 class TaskSignal extends AbortSignal {
   /**
-   * Make a TaskSignal instance from a TaskController instance.
-   * @private
-   * @param {TaskController} controller
-   * @param {string} priority
-   */
-  static make_(controller, priority) {
-    Object.setPrototypeOf(controller.signal, TaskSignal.prototype);
-    controller.signal.priority_ = priority;
-  }
-
-  /**
    * The priority of the task, user-visible by default.
    * @readonly
    * @type {string}
@@ -121,7 +110,9 @@ class TaskController extends AbortController {
      */
     this.isPriorityChanging_ = false;
 
-    TaskSignal.make_(this, priority);
+    // Morph the AbortSignal instance into a TaskSignal instance.
+    Object.setPrototypeOf(this.signal, TaskSignal.prototype);
+    this.signal.priority_ = priority;
   }
 
   /**

--- a/src/task-controller.js
+++ b/src/task-controller.js
@@ -48,7 +48,7 @@ class TaskSignal extends AbortSignal {
   }
 
   /**
-   * The callback to be called when the priority of the task changes.
+   * The callback to be called when the priority of the signal changes.
    * @type {Function}
    */
   get onprioritychange() {

--- a/src/task-controller.js
+++ b/src/task-controller.js
@@ -62,7 +62,6 @@ class TaskSignal extends AbortSignal {
  * @param {TaskController} controller
  */
 function makeTaskSignal(controller) {
-  // Change the prototype of the signal to TaskSignal.prototype.
   Object.setPrototypeOf(controller.signal, TaskSignal.prototype);
 
   // Connect the priority property to the controller's priority.

--- a/test/test.taskcontroller.js
+++ b/test/test.taskcontroller.js
@@ -163,6 +163,28 @@ describe('TaskSignal', function() {
       expect(signal instanceof EventTarget).to.equal(true);
     });
   });
+
+  describe('works with web apis', function() {
+    it('works with fetch', function(done) {
+      const controller = new TaskController();
+      const signal = controller.signal;
+
+      // the /slow-api endpoint is mocked in karma.conf.js
+      // it will delay the response for 1 second
+      fetch('/slow-api', {signal}).then(() => {
+        assert.ok(false, 'fetch resolved instead of being aborted');
+      }).catch((error) => {
+        expect(error.message).to.equal('Aborted by TaskController.');
+        done();
+      });
+
+      setTimeout(() => {
+        controller.abort(
+            new Error('Aborted by TaskController.'),
+        );
+      }, 10);
+    });
+  });
 });
 
 describe('TaskPriorityChangeEvent', function() {

--- a/test/test.taskcontroller.js
+++ b/test/test.taskcontroller.js
@@ -15,7 +15,7 @@
  */
 
 import {SCHEDULER_PRIORITIES} from '../src/scheduler-priorities.js';
-import {TaskController, TaskPriorityChangeEvent}
+import {TaskController, TaskSignal, TaskPriorityChangeEvent}
   from '../src/task-controller.js';
 
 describe('TaskController', function() {
@@ -48,6 +48,17 @@ describe('TaskController', function() {
       const signal = controller.signal;
       try {
         signal.priority = 'background';
+        assert.ok(false);
+      } catch {
+        assert.ok(true);
+      }
+    });
+
+    it('should have read-only aborted', function() {
+      const controller = new TaskController();
+      const signal = controller.signal;
+      try {
+        signal.aborted = true;
         assert.ok(false);
       } catch {
         assert.ok(true);
@@ -113,6 +124,17 @@ describe('TaskController', function() {
 });
 
 describe('TaskSignal', function() {
+  describe('#constructor', function() {
+    it('should throw an error.', function() {
+      try {
+        new TaskSignal();
+        assert.okay(false);
+      } catch (e) {
+        expect(e.name).to.equal('TypeError');
+      }
+    });
+  });
+
   describe('#onprioritychange', function() {
     it('should return the handler it was set to', function() {
       [function() {}, {}].forEach((handler) => {
@@ -121,6 +143,24 @@ describe('TaskSignal', function() {
         controller.signal.onprioritychange = handler;
         expect(signal.onprioritychange).to.equal(handler);
       });
+    });
+  });
+
+  describe('instanceof', function() {
+    it('should be instanceof TaskSignal', function() {
+      const controller = new TaskController();
+      const signal = controller.signal;
+      expect(signal instanceof TaskSignal).to.equal(true);
+    });
+    it('should be instanceof AbortSignal', function() {
+      const controller = new TaskController();
+      const signal = controller.signal;
+      expect(signal instanceof AbortSignal).to.equal(true);
+    });
+    it('should be instanceof EventTarget', function() {
+      const controller = new TaskController();
+      const signal = controller.signal;
+      expect(signal instanceof EventTarget).to.equal(true);
     });
   });
 });

--- a/test/test.taskcontroller.js
+++ b/test/test.taskcontroller.js
@@ -23,7 +23,7 @@ describe('TaskController', function() {
     it('should throw an error if the priority is not valid.', function() {
       try {
         new TaskController('unknown');
-        assert.okay(false);
+        assert.ok(false);
       } catch (e) {
         expect(e.name).to.equal('TypeError');
       }
@@ -89,7 +89,7 @@ describe('TaskController', function() {
       const controller = new TaskController();
       try {
         controller.setPriority('unknown');
-        assert.okay(false);
+        assert.ok(false);
       } catch (e) {
         expect(e.name).to.equal('TypeError');
       }
@@ -128,7 +128,7 @@ describe('TaskSignal', function() {
     it('should throw an error.', function() {
       try {
         new TaskSignal();
-        assert.okay(false);
+        assert.ok(false);
       } catch (e) {
         expect(e.name).to.equal('TypeError');
       }

--- a/types/scheduler.d.ts
+++ b/types/scheduler.d.ts
@@ -19,7 +19,7 @@
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Prioritized_Task_Scheduling_API#task_priorities)
  */
-export type TaskPriority = 'user-blocking' | 'user-visible' | 'background';
+export type TaskPriority = "user-blocking" | "user-visible" | "background";
 
 /**
  * {@link Scheduler.postTask} options.
@@ -43,7 +43,7 @@ export type SchedulerPostTaskOptions = {
 type TaskControllerOptions = {
   /** The {@link TaskPriority} of the signal associated with this {@link TaskController}. One of `"user-blocking"`, `"user-visible"`, or `"background"`. The default is `"user-visible"`. */
   priority?: TaskPriority;
-}
+};
 
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/TaskPriorityChangeEvent/TaskPriorityChangeEvent#options) */
 interface TaskPriorityChangeEventInit extends EventInit {
@@ -61,7 +61,10 @@ declare global {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Scheduler/postTask)
      */
-    postTask<T extends unknown>(callback: () => T, options?: SchedulerPostTaskOptions): Promise<T>;
+    postTask<T extends unknown>(
+      callback: () => T,
+      options?: SchedulerPostTaskOptions
+    ): Promise<T>;
     /**
      * Returns a promise that yields to the event loop when awaited, allowing continuation in a new task.
      *
@@ -119,7 +122,9 @@ declare global {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/TaskSignal/prioritychange_event)
      */
-    onprioritychange: (event: TaskPriorityChangeEvent) => void;
+    onprioritychange:
+      | null
+      | ((this: TaskSignal, event: TaskPriorityChangeEvent) => any);
   }
 
   /**


### PR DESCRIPTION
## Motivation
<img width="744" alt="image" src="https://github.com/user-attachments/assets/a0305f33-6f71-447c-8b3a-bc4a5eda36ae" />

I was surprised that this shim doesn't implement TaskSignal. It took me a while to debug why it was the case :)

## Changes
Implement `TaskSignal` class that extends `AbortSignal` class.
I use `Object.setPrototypeOf(abortSignal, TaskSignal.prototype)` to morph AbortSignal into TaskSignal.

## For follow-up
This will make possible to implement `TaskSignal.any()` method in the future.